### PR TITLE
v1.3.0 release candidate

### DIFF
--- a/firmware/common/feb/rtl/AtlasRd53Core.vhd
+++ b/firmware/common/feb/rtl/AtlasRd53Core.vhd
@@ -2,7 +2,7 @@
 -- File       : AtlasRd53Core.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-12-08
--- Last update: 2018-05-08
+-- Last update: 2018-05-09
 -------------------------------------------------------------------------------
 -- Description: Top-Level module using four lanes of 10 Gbps PGPv3 communication
 -------------------------------------------------------------------------------
@@ -141,8 +141,18 @@ architecture mapping of AtlasRd53Core is
    signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0);
    signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0);
 
-   signal axisMasters : AxiStreamMasterArray(3 downto 0);
-   signal axisSlaves  : AxiStreamSlaveArray(3 downto 0);
+   signal txDataMasters : AxiStreamMasterArray(3 downto 0);
+   signal txDataSlaves  : AxiStreamSlaveArray(3 downto 0);
+
+   signal txCmdMasters : AxiStreamMasterArray(3 downto 0);
+   signal txCmdSlaves  : AxiStreamSlaveArray(3 downto 0);
+   signal rxCmdMasters : AxiStreamMasterArray(3 downto 0);
+   signal rxCmdSlaves  : AxiStreamSlaveArray(3 downto 0);
+
+   signal txTluMaster : AxiStreamMasterType;
+   signal txTluSlave  : AxiStreamSlaveType;
+   signal rxTluMaster : AxiStreamMasterType;
+   signal rxTluSlave  : AxiStreamSlaveType;
 
    signal rxLinkUp : slv(3 downto 0);
    signal txLinkUp : slv(3 downto 0);
@@ -245,6 +255,11 @@ begin
          axilReadSlave   => axilReadSlaves(TLU_INDEX_C),
          axilWriteMaster => axilWriteMasters(TLU_INDEX_C),
          axilWriteSlave  => axilWriteSlaves(TLU_INDEX_C),
+         -- Streaming TLU Interface (axilClk domain)
+         sTluMaster      => rxTluMaster,
+         sTluSlave       => rxTluSlave,
+         mTluMaster      => txTluMaster,
+         mTluSlave       => txTluSlave,
          -- Timing Clocks
          clk640MHz       => clk640MHz,
          rst640MHz       => rst640MHz,
@@ -284,9 +299,14 @@ begin
             axilReadSlave   => axilReadSlaves(DPORT0_INDEX_C+i),
             axilWriteMaster => axilWriteMasters(DPORT0_INDEX_C+i),
             axilWriteSlave  => axilWriteSlaves(DPORT0_INDEX_C+i),
-            -- Streaming RD43 Data (axilClk domain)
-            axisMaster      => axisMasters(i),
-            axisSlave       => axisSlaves(i),
+            -- Streaming RD43 Data Interface (axilClk domain)
+            mDataMaster     => txDataMasters(i),
+            mDataSlave      => txDataSlaves(i),
+            -- Streaming RD43 CMD Interface (axilClk domain)
+            sCmdMaster      => rxCmdMasters(i),
+            sCmdSlave       => rxCmdSlaves(i),
+            mCmdMaster      => txCmdMasters(i),
+            mCmdSlave       => txCmdSlaves(i),
             -- Timing Clocks
             clk640MHz       => clk640MHz,
             rst640MHz       => rst640MHz,
@@ -362,9 +382,19 @@ begin
          axilReadSlave   => axilReadSlave,
          axilWriteMaster => axilWriteMaster,
          axilWriteSlave  => axilWriteSlave,
-         -- Streaming RD43 Data (axilClk domain)
-         axisMasters     => axisMasters,
-         axisSlaves      => axisSlaves,
+         -- Streaming RD43 Data Interface (axilClk domain)
+         sDataMasters    => txDataMasters,
+         sDataSlaves     => txDataSlaves,
+         -- Streaming RD43 CMD Interface (axilClk domain)
+         sCmdMasters     => txCmdMasters,
+         sCmdSlaves      => txCmdSlaves,
+         mCmdMasters     => rxCmdMasters,
+         mCmdSlaves      => rxCmdSlaves,
+         -- Streaming TLU Interface (axilClk domain)
+         sTluMaster      => txTluMaster,
+         sTluSlave       => txTluSlave,
+         mTluMaster      => rxTluMaster,
+         mTluSlave       => rxTluSlave,
          -- Stable Reference IDELAY Clock and Reset
          refClk300MHz    => refClk300MHz,
          refRst300MHz    => refRst300MHz,

--- a/firmware/common/feb/rtl/AtlasRd53Dport.vhd
+++ b/firmware/common/feb/rtl/AtlasRd53Dport.vhd
@@ -2,7 +2,7 @@
 -- File       : AtlasRd53Dport.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-12-18
--- Last update: 2018-05-05
+-- Last update: 2018-05-09
 -------------------------------------------------------------------------------
 -- Description: Hit/Trig Module
 -------------------------------------------------------------------------------
@@ -40,9 +40,14 @@ entity AtlasRd53Dport is
       axilReadSlave   : out AxiLiteReadSlaveType;
       axilWriteMaster : in  AxiLiteWriteMasterType;
       axilWriteSlave  : out AxiLiteWriteSlaveType;
-      -- Streaming RD43 Data (axilClk domain)
-      axisMaster      : out AxiStreamMasterType;
-      axisSlave       : in  AxiStreamSlaveType;
+      -- Streaming RD43 Data Interface (axilClk domain)
+      mDataMaster     : out AxiStreamMasterType;
+      mDataSlave      : in  AxiStreamSlaveType;
+      -- Streaming RD43 CMD Interface (axilClk domain)
+      sCmdMaster      : in  AxiStreamMasterType;
+      sCmdSlave       : out AxiStreamSlaveType;
+      mCmdMaster      : out AxiStreamMasterType;
+      mCmdSlave       : in  AxiStreamSlaveType;
       -- Timing Clocks
       clk640MHz       : in  sl;
       rst640MHz       : in  sl;
@@ -139,6 +144,8 @@ begin
    -- Place holder for future code
    axilReadSlave  <= AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
    axilWriteSlave <= AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
+   sCmdSlave      <= AXI_STREAM_SLAVE_FORCE_C;
+   mCmdMaster     <= AXI_STREAM_MASTER_INIT_C;
 
    GEN_LANE : for i in 3 downto 0 generate
       U_rx_lane : aurora_rx_top_xapp
@@ -206,7 +213,7 @@ begin
          -- AXI Stream Interface
          mAxisClk      => axilClk,
          mAxisRst      => axilRst,
-         mAxisMaster   => axisMaster,
-         mAxisSlave    => axisSlave);
+         mAxisMaster   => mDataMaster,
+         mAxisSlave    => mDataSlave);
 
 end mapping;

--- a/firmware/common/feb/rtl/AtlasRd53HitTrig.vhd
+++ b/firmware/common/feb/rtl/AtlasRd53HitTrig.vhd
@@ -2,7 +2,7 @@
 -- File       : AtlasRd53HitTrig.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-12-18
--- Last update: 2018-05-05
+-- Last update: 2018-05-09
 -------------------------------------------------------------------------------
 -- Description: Hit/Trig Module
 -------------------------------------------------------------------------------
@@ -20,6 +20,8 @@ use ieee.std_logic_1164.all;
 
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;
+use work.AxiStreamPkg.all;
+use work.Pgp3Pkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
@@ -36,6 +38,11 @@ entity AtlasRd53HitTrig is
       axilReadSlave   : out AxiLiteReadSlaveType;
       axilWriteMaster : in  AxiLiteWriteMasterType;
       axilWriteSlave  : out AxiLiteWriteSlaveType;
+      -- Streaming TLU Interface (axilClk domain)
+      sTluMaster      : in  AxiStreamMasterType;
+      sTluSlave       : out AxiStreamSlaveType;
+      mTluMaster      : out AxiStreamMasterType;
+      mTluSlave       : in  AxiStreamSlaveType;
       -- Timing Clocks
       clk640MHz       : in  sl;
       rst640MHz       : in  sl;
@@ -116,5 +123,7 @@ begin
    -- Place holder for future code
    axilReadSlave  <= AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
    axilWriteSlave <= AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
+   sTluSlave      <= AXI_STREAM_SLAVE_FORCE_C;
+   mTluMaster     <= AXI_STREAM_MASTER_INIT_C;
 
 end mapping;

--- a/firmware/common/feb/rtl/AtlasRd53Pgp3AxisFifo.vhd
+++ b/firmware/common/feb/rtl/AtlasRd53Pgp3AxisFifo.vhd
@@ -1,0 +1,99 @@
+-------------------------------------------------------------------------------
+-- File       : AtlasRd53Pgp3AxisFifo.vhd
+-- Company    : SLAC National Accelerator Laboratory
+-- Created    : 2017-12-08
+-- Last update: 2018-05-09
+-------------------------------------------------------------------------------
+-- Description: Top-Level module using four lanes of 10 Gbps PGPv3 communication
+-------------------------------------------------------------------------------
+-- This file is part of 'ATLAS RD53 DEV'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'ATLAS RD53 DEV', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.StdRtlPkg.all;
+use work.AxiStreamPkg.all;
+use work.Pgp3Pkg.all;
+
+entity AtlasRd53Pgp3AxisFifo is
+   generic (
+      TPD_G : time    := 1 ns;
+      TX_G  : boolean := true;
+      RX_G  : boolean := true);
+   port (
+      -- System Interface (axilClk domain)
+      sysClk      : in  sl;
+      sysRst      : in  sl;
+      sAxisMaster : in  AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+      sAxisSlave  : out AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+      mAxisMaster : out AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+      mAxisSlave  : in  AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C;
+      -- PGP Interface (pgpClk domain)
+      pgpClk      : in  sl;
+      pgpRst      : in  sl;
+      pgpRxMaster : in  AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+      pgpRxCtrl   : out AxiStreamCtrlType   := AXI_STREAM_CTRL_UNUSED_C;
+      pgpTxMaster : out AxiStreamMasterType := AXI_STREAM_MASTER_INIT_C;
+      pgpTxSlave  : in  AxiStreamSlaveType  := AXI_STREAM_SLAVE_FORCE_C);
+end AtlasRd53Pgp3AxisFifo;
+
+architecture mapping of AtlasRd53Pgp3AxisFifo is
+
+begin
+
+   GEN_TX : if (TX_G) generate
+      U_Fifo : entity work.AxiStreamFifoV2
+         generic map (
+            TPD_G               => TPD_G,
+            SLAVE_READY_EN_G    => true,
+            BRAM_EN_G           => false,
+            GEN_SYNC_FIFO_G     => false,
+            FIFO_ADDR_WIDTH_G   => 4,
+            SLAVE_AXI_CONFIG_G  => PGP3_AXIS_CONFIG_C,
+            MASTER_AXI_CONFIG_G => PGP3_AXIS_CONFIG_C)
+         port map (
+            -- Slave Port
+            sAxisClk    => sysClk,
+            sAxisRst    => sysRst,
+            sAxisMaster => sAxisMaster,
+            sAxisSlave  => sAxisSlave,
+            -- Master Port
+            mAxisClk    => pgpClk,
+            mAxisRst    => pgpRst,
+            mAxisMaster => pgpTxMaster,
+            mAxisSlave  => pgpTxSlave);
+   end generate;
+
+   GEN_RX : if (RX_G) generate
+      U_Fifo : entity work.AxiStreamFifoV2
+         generic map (
+            TPD_G               => TPD_G,
+            SLAVE_READY_EN_G    => false,
+            BRAM_EN_G           => true,
+            GEN_SYNC_FIFO_G     => false,
+            FIFO_ADDR_WIDTH_G   => 9,
+            FIFO_FIXED_THRESH_G => true,
+            FIFO_PAUSE_THRESH_G => 128,
+            SLAVE_AXI_CONFIG_G  => PGP3_AXIS_CONFIG_C,
+            MASTER_AXI_CONFIG_G => PGP3_AXIS_CONFIG_C)
+         port map (
+            -- Slave Port
+            sAxisClk    => pgpClk,
+            sAxisRst    => pgpRst,
+            sAxisMaster => pgpRxMaster,
+            sAxisCtrl   => pgpRxCtrl,
+            -- Master Port
+            mAxisClk    => sysClk,
+            mAxisRst    => sysRst,
+            mAxisMaster => mAxisMaster,
+            mAxisSlave  => mAxisSlave);
+   end generate;
+
+end mapping;

--- a/firmware/common/pcie/rtl/PgpLaneWrapper.vhd
+++ b/firmware/common/pcie/rtl/PgpLaneWrapper.vhd
@@ -35,7 +35,6 @@ entity PgpLaneWrapper is
       TPD_G           : time             := 1 ns;
       RATE_G          : string           := "10.3125Gbps";  -- or "6.25Gbps"
       REFCLK_WIDTH_G  : positive         := 2;
-      NUM_VC_G        : positive         := 2;
       AXI_BASE_ADDR_G : slv(31 downto 0) := (others => '0'));
    port (
       -- QSFP[0] Ports
@@ -194,7 +193,7 @@ begin
             TPD_G           => TPD_G,
             RATE_G          => RATE_G,
             LANE_G          => i,
-            NUM_VC_G        => NUM_VC_G,
+            NUM_VC_G        => 16,
             AXI_BASE_ADDR_G => AXI_CONFIG_C(i).baseAddr)
          port map (
             -- QPLL Interface

--- a/firmware/common/rce/rtl/DpmPgpLaneWrapper.vhd
+++ b/firmware/common/rce/rtl/DpmPgpLaneWrapper.vhd
@@ -169,7 +169,7 @@ begin
          generic map (
             TPD_G           => TPD_G,
             LANE_G          => i,
-            NUM_VC_G        => 2,
+            NUM_VC_G        => 16,
             AXI_BASE_ADDR_G => AXI_CONFIG_C(i).baseAddr)
          port map (
             -- PGP Serial Ports
@@ -201,7 +201,7 @@ begin
          TPD_G                => TPD_G,
          NUM_SLAVES_G         => NUM_LANE_C,
          MODE_G               => "ROUTED",
-         TDEST_ROUTES_G       => (0 => "0000000-", 1 => "0000001-"),
+         TDEST_ROUTES_G       => (0 => "0000----", 1 => "0001----"),
          ILEAVE_EN_G          => true,
          ILEAVE_ON_NOTVALID_G => false,
          ILEAVE_REARB_G       => 128,
@@ -222,7 +222,7 @@ begin
          TPD_G          => TPD_G,
          NUM_MASTERS_G  => NUM_LANE_C,
          MODE_G         => "ROUTED",
-         TDEST_ROUTES_G => (0 => "0000000-", 1 => "0000001-"),
+         TDEST_ROUTES_G => (0 => "0000----", 1 => "0001----"),
          PIPE_STAGES_G  => 1)
       port map (
          -- Clock and reset

--- a/firmware/common/rce/rtl/DtmPgpLaneWrapper.vhd
+++ b/firmware/common/rce/rtl/DtmPgpLaneWrapper.vhd
@@ -77,7 +77,7 @@ begin
       generic map (
          TPD_G           => TPD_G,
          LANE_G          => 0,
-         NUM_VC_G        => 2,
+         NUM_VC_G        => 16,
          AXI_BASE_ADDR_G => AXI_BASE_ADDR_G)
       port map (
          -- PGP Serial Ports

--- a/firmware/common/rce/rtl/PgpLane.vhd
+++ b/firmware/common/rce/rtl/PgpLane.vhd
@@ -80,7 +80,7 @@ begin
       generic map(
          TPD_G            => TPD_G,
          NUM_LANES_G      => 1,
-         NUM_VC_G         => 2,
+         NUM_VC_G         => NUM_VC_G,
          RATE_G           => "6.25Gbps",
          REFCLK_TYPE_G    => PGP3_REFCLK_250_C,  -- 250 MHz reference clock
          REFCLK_G         => true,               -- TRUE: use pgpRefClkIn

--- a/firmware/targets/AtlasRd53FebPgp3_6Gbps/images/AtlasRd53FebPgp3_6Gbps-0x00000018-20180508200858-ruckman-fe900370.mcs
+++ b/firmware/targets/AtlasRd53FebPgp3_6Gbps/images/AtlasRd53FebPgp3_6Gbps-0x00000018-20180508200858-ruckman-fe900370.mcs
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2afd1b631554e6a35e0130f535f14a440d472d9aa4a9a09da88be4323e432787
-size 18406236

--- a/firmware/targets/AtlasRd53FebPgp3_6Gbps/images/AtlasRd53FebPgp3_6Gbps-0x00000018-20180509165433-ruckman-9dd984d0.mcs
+++ b/firmware/targets/AtlasRd53FebPgp3_6Gbps/images/AtlasRd53FebPgp3_6Gbps-0x00000018-20180509165433-ruckman-9dd984d0.mcs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19b2068c87bbd811130c8f0b89036bc162db017a11e6e1832a50c927fc5120da
+size 18406236

--- a/software/python/common/_pcie.py
+++ b/software/python/common/_pcie.py
@@ -52,7 +52,7 @@ class Pcie(pyrogue.Device):
                 memBase         = memMap,
                 name            = ('Pgp3Mon[%d]' % i),
                 offset          = (0x00800000 + i*0x10000),  
-                numVc           = 2,
+                numVc           = 16,
                 writeEn         = True,
                 expand          = False,
             ))

--- a/software/python/common/_top.py
+++ b/software/python/common/_top.py
@@ -221,6 +221,7 @@ class Top(pyrogue.Device):
         
         # Create an empty data stream array
         self.dataStream = [None] * 4
+        self.cmdStream  = [None] * 4
         
         # Check if emulating the GUI interface
         if (hwEmu):
@@ -234,23 +235,21 @@ class Top(pyrogue.Device):
             # static boost::shared_ptr<rogue::hardware::axi::AxiStreamDma> create (std::string path, uint32_t dest, bool ssiEnable);
             ########################################################################################################################
         
-            # Connect the SRPv3 to QSFP[port].Lane[0].VC[1]
-            srpStream  = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+1,1)
+            # Connect the SRPv3 to QSFP[port].Lane[0].VC[0]
+            srpStream  = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+0,1)
             memMap = rogue.protocols.srp.SrpV3()                
             pr.streamConnectBiDir( memMap, srpStream )             
             
-            # Create the Raw Data stream interface to QSFP[port].Lane[0].VC[0]
-            self.dataStream[0] = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+(32*0),1)
+            # Create the TLU stream interface to QSFP[port].Lane[0].VC[1]
+            self.tluStream = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+1,1)            
             
-            # Create the Raw Data stream interface to QSFP[port].Lane[1].VC[0]
-            self.dataStream[1] = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+(32*1),1)
-            
-            # Create the Raw Data stream interface to QSFP[port].Lane[2].VC[0]
-            self.dataStream[2] = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+(32*2),1)
-            
-            # Create the Raw Data stream interface to QSFP[port].Lane[3].VC[0]
-            self.dataStream[3] = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+(32*3),1)            
-            
+            for i in range(4):
+                # Create the RD53 Data stream interface to QSFP[port].Lane[0].VC[2+i]
+                self.dataStream[i] = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+2+i,1)
+                
+                # Create the RD53 CMD stream interface to QSFP[port].Lane[0].VC[2+i]
+                self.cmdStream[i] = rogue.hardware.axi.AxiStreamDma(dev,(128*port)+6+i,1)                
+                       
         ######################################################################
             
         # Add devices


### PR DESCRIPTION
### Description
Updating PCIe, DPM and HSIO from 2 VC to 16 VC 
Change the FEB to 10 VC

### New Virtual Channel Mapping
PGPv3[Lane=0].[VC=0] = [FEB SRPv3 Register Access](https://confluence.slac.stanford.edu/x/cRmVD)
PGPv3[Lane=0].[VC=1] = [TLU Streaming Interface](https://twiki.cern.ch/twiki/bin/view/MimosaTelescope/TLU)
PGPv3[Lane=0].[VC=2] = [RD53[DPORT=0] Streaming Data Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=0].[VC=3] = [RD53[DPORT=1] Streaming Data Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=0].[VC=4] = [RD53[DPORT=2] Streaming Data Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=0].[VC=5] = [RD53[DPORT=3] Streaming Data Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=0].[VC=6] = [RD53[DPORT=0] Streaming CMD Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=0].[VC=7] = [RD53[DPORT=1] Streaming CMD Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=0].[VC=8] = [RD53[DPORT=2] Streaming CMD Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=0].[VC=9] = [RD53[DPORT=3] Streaming CMD Interface](https://cds.cern.ch/record/2287593/files/%20RD53A_Manual_V3-24.pdf)
PGPv3[Lane=1] = Unused
PGPv3[Lane=2] = Unused
PGPv3[Lane=3] = Unused

### Note
Backend targets chaned to 16 VC, which is the max. possible VC and allows us to support any type of 6.25Gbps PGPv3 link.  Especially if we change the FEB from 10 VC to a new value